### PR TITLE
프로필 수정 API & 이미지, input 상태 데이터 reset 처리

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,6 +33,11 @@ const nextConfig = {
         hostname: 't1.kakaocdn.net',
         pathname: '**',
       },
+      {
+        protocol: 'https',
+        hostname: 's3.ap-northeast-2.amazonaws.com',
+        pathname: '**',
+      },
     ],
   },
   async rewrites() {

--- a/src/app/(afterLogin)/(main)/mypage/_components/MyPageMain.tsx
+++ b/src/app/(afterLogin)/(main)/mypage/_components/MyPageMain.tsx
@@ -17,11 +17,11 @@ import { getCookies } from '@/app/_store/cookie/cookies';
 import { AccountDeletionType, UserDataType } from '@/type';
 import { useEffect, useState } from 'react';
 
-const determineTargetType = (isLastMember: boolean, isHouseholder: boolean): AccountDeletionType => {
+const determineTargetType = (isLastMember: boolean, isHouseHolder: boolean): AccountDeletionType => {
   if (isLastMember) {
     return 'lastMember';
   }
-  if (isHouseholder) {
+  if (isHouseHolder) {
     return 'householder';
   }
 

--- a/src/app/(afterLogin)/(main)/mypage/_components/MyPageMain.tsx
+++ b/src/app/(afterLogin)/(main)/mypage/_components/MyPageMain.tsx
@@ -41,8 +41,8 @@ export default function MyPageMain() {
 
   useEffect(() => {
     if (userData) {
-      const { isLastMember, isHouseholder } = userData;
-      setTargetType(determineTargetType(isLastMember, isHouseholder));
+      const { isLastMember, isHouseHolder } = userData;
+      setTargetType(determineTargetType(isLastMember, isHouseHolder));
     }
   }, [userData]);
 
@@ -72,7 +72,7 @@ export default function MyPageMain() {
             <MyTitle name={userData.nickname} profileImage={userData.profileImgLink} />
             <Border />
             {/* <NotificationSetting notifications={DUMMY_DATA.notifications} /> */}
-            <FamilySetting isHouseholder={userData.isHouseholder} />
+            <FamilySetting isHouseHolder={userData.isHouseHolder} />
             {/* <AddHome onClick={handleModal} /> */}
             <AccountSetting targetType={targetType} />
             <ServiceInfo />

--- a/src/app/(afterLogin)/(main)/mypage/_components/family/FamilySetting.tsx
+++ b/src/app/(afterLogin)/(main)/mypage/_components/family/FamilySetting.tsx
@@ -6,10 +6,10 @@ import FamilyIcon from '@/assets/icons/family/family.svg';
 import { useRouter } from 'next/navigation';
 
 interface Props {
-  isHouseholder: boolean;
+  isHouseHolder: boolean;
 }
 
-export default function FamilySetting({ isHouseholder }: Props) {
+export default function FamilySetting({ isHouseHolder }: Props) {
   const router = useRouter();
 
   const handleFamilySelect = () => {
@@ -28,7 +28,7 @@ export default function FamilySetting({ isHouseholder }: Props) {
         content="다른 가족으로 이동하거나 가족을 새로 만들 수 있어요"
         onClick={handleFamilySelect}
       />
-      {isHouseholder && (
+      {isHouseHolder && (
         <FamilyItem
           title="가족 상태 수정"
           content="가족 프로필을 수정하거나 가족을 삭제할 수 있어요"

--- a/src/app/(afterLogin)/(profile)/family-edit/_components/FamilyDelete.tsx
+++ b/src/app/(afterLogin)/(profile)/family-edit/_components/FamilyDelete.tsx
@@ -3,9 +3,11 @@ import { apiRoutes } from '@/app/_api/apiRoutes';
 import Modal from '@/app/_components/common/modal/Modal';
 import { FAMILY_DELETE_CONTENT } from '@/app/_constants/modal';
 import { deleteCookies, getCookies } from '@/app/_store/cookie/cookies';
+import { useImageUploadStore } from '@/app/_store/imageUploadStore';
 import { useRouter } from 'next/navigation';
 
 export default function FamilyDelete() {
+  const { imageReset } = useImageUploadStore();
   const router = useRouter();
 
   const handleCancelClick = () => {
@@ -20,6 +22,7 @@ export default function FamilyDelete() {
       console.error(e);
     }
     deleteCookies('groupId');
+    imageReset();
     router.replace('/family-select');
   };
 

--- a/src/app/(afterLogin)/(profile)/family-edit/_components/FamilyProfileEditMain.tsx
+++ b/src/app/(afterLogin)/(profile)/family-edit/_components/FamilyProfileEditMain.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import ProfileMain from '@/app/(afterLogin)/(profile)/_components/ProfileMain';
+import { getData } from '@/app/_api/api';
+import { apiRoutes } from '@/app/_api/apiRoutes';
+import { getCookies } from '@/app/_store/cookie/cookies';
+import { useEffect, useState } from 'react';
+
+export default function FamilyProfileEditMain() {
+  const [title, setTitle] = useState('');
+  const [profileImage, setProfileImage] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const groupId = getCookies('groupId');
+        const { data } = await getData({ path: `${apiRoutes.getFamily}/${groupId}` });
+        const { groupName, groupImage: images } = data;
+        setTitle(groupName);
+        setProfileImage(images);
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, []);
+
+  return <ProfileMain profileImage={profileImage} value={title} inputType="familyEdit" />;
+}

--- a/src/app/(afterLogin)/(profile)/family-edit/_components/FamilyProfileEditMain.tsx
+++ b/src/app/(afterLogin)/(profile)/family-edit/_components/FamilyProfileEditMain.tsx
@@ -3,16 +3,19 @@
 import ProfileMain from '@/app/(afterLogin)/(profile)/_components/ProfileMain';
 import { getData } from '@/app/_api/api';
 import { apiRoutes } from '@/app/_api/apiRoutes';
+import Loading from '@/app/_components/common/loading/Loading';
 import { getCookies } from '@/app/_store/cookie/cookies';
 import { useEffect, useState } from 'react';
 
 export default function FamilyProfileEditMain() {
   const [title, setTitle] = useState('');
   const [profileImage, setProfileImage] = useState('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   useEffect(() => {
     (async () => {
       try {
+        setIsLoading(true);
         const groupId = getCookies('groupId');
         const { data } = await getData({ path: `${apiRoutes.getFamily}/${groupId}` });
         const { groupName, groupImage: images } = data;
@@ -20,9 +23,11 @@ export default function FamilyProfileEditMain() {
         setProfileImage(images);
       } catch (e) {
         console.error(e);
+      } finally {
+        setIsLoading(false);
       }
     })();
   }, []);
 
-  return <ProfileMain profileImage={profileImage} value={title} inputType="familyEdit" />;
+  return isLoading ? <Loading /> : <ProfileMain profileImage={profileImage} value={title} inputType="familyEdit" />;
 }

--- a/src/app/(afterLogin)/(profile)/family-edit/page.tsx
+++ b/src/app/(afterLogin)/(profile)/family-edit/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 export default function FamilyEditPage() {
   return (
-    <div className="relative min-h-screen">
+    <div className="flex flex-col relative min-h-screen">
       <BasicHeader title="가족 상태 수정" hasRightButton />
       <FamilyProfileEditMain />
       <Link href="/family-edit/family-delete" className="text-primary font-body absolute bottom-16 left-16">

--- a/src/app/(afterLogin)/(profile)/family-edit/page.tsx
+++ b/src/app/(afterLogin)/(profile)/family-edit/page.tsx
@@ -1,4 +1,4 @@
-import ProfileEditMain from '@/app/(afterLogin)/(profile)/_components/ProfileEditMain';
+import FamilyProfileEditMain from '@/app/(afterLogin)/(profile)/family-edit/_components/FamilyProfileEditMain';
 import BasicHeader from '@/app/_components/common/header/BasicHeader';
 import Link from 'next/link';
 
@@ -6,7 +6,7 @@ export default function FamilyEditPage() {
   return (
     <div className="relative min-h-screen">
       <BasicHeader title="가족 상태 수정" hasRightButton />
-      <ProfileEditMain />
+      <FamilyProfileEditMain />
       <Link href="/family-edit/family-delete" className="text-primary font-body absolute bottom-16 left-16">
         가족 삭제
       </Link>

--- a/src/app/(afterLogin)/(profile)/profile/components/UserProfileEditMain.tsx
+++ b/src/app/(afterLogin)/(profile)/profile/components/UserProfileEditMain.tsx
@@ -3,24 +3,29 @@
 import ProfileMain from '@/app/(afterLogin)/(profile)/_components/ProfileMain';
 import { getData } from '@/app/_api/api';
 import { apiRoutes } from '@/app/_api/apiRoutes';
+import Loading from '@/app/_components/common/loading/Loading';
 import { useEffect, useState } from 'react';
 
 export default function UserProfileEditMain() {
   const [title, setTitle] = useState('');
   const [profileImage, setProfileImage] = useState('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   useEffect(() => {
     (async () => {
       try {
+        setIsLoading(true);
         const { data } = await getData({ path: `${apiRoutes.getUserData}` });
         const { nickname, profileImgLink: images } = data;
         setTitle(nickname);
         setProfileImage(images);
       } catch (e) {
         console.error(e);
+      } finally {
+        setIsLoading(false);
       }
     })();
   }, []);
 
-  return <ProfileMain profileImage={profileImage} value={title} inputType="profile" />;
+  return isLoading ? <Loading /> : <ProfileMain profileImage={profileImage} value={title} inputType="profile" />;
 }

--- a/src/app/(afterLogin)/(profile)/profile/components/UserProfileEditMain.tsx
+++ b/src/app/(afterLogin)/(profile)/profile/components/UserProfileEditMain.tsx
@@ -13,8 +13,8 @@ export default function UserProfileEditMain() {
     (async () => {
       try {
         const { data } = await getData({ path: `${apiRoutes.getUserData}` });
-        const { nickName, profileImgLink: images } = data;
-        setTitle(nickName);
+        const { nickname, profileImgLink: images } = data;
+        setTitle(nickname);
         setProfileImage(images);
       } catch (e) {
         console.error(e);

--- a/src/app/(afterLogin)/(profile)/profile/components/UserProfileEditMain.tsx
+++ b/src/app/(afterLogin)/(profile)/profile/components/UserProfileEditMain.tsx
@@ -3,20 +3,18 @@
 import ProfileMain from '@/app/(afterLogin)/(profile)/_components/ProfileMain';
 import { getData } from '@/app/_api/api';
 import { apiRoutes } from '@/app/_api/apiRoutes';
-import { getCookies } from '@/app/_store/cookie/cookies';
 import { useEffect, useState } from 'react';
 
-export default function ProfileEditMain() {
+export default function UserProfileEditMain() {
   const [title, setTitle] = useState('');
   const [profileImage, setProfileImage] = useState('');
 
   useEffect(() => {
     (async () => {
       try {
-        const groupId = getCookies('groupId');
-        const { data } = await getData({ path: `${apiRoutes.getFamily}/${groupId}` });
-        const { groupName, groupImage: images } = data;
-        setTitle(groupName);
+        const { data } = await getData({ path: `${apiRoutes.getUserData}` });
+        const { nickName, profileImgLink: images } = data;
+        setTitle(nickName);
         setProfileImage(images);
       } catch (e) {
         console.error(e);
@@ -24,5 +22,5 @@ export default function ProfileEditMain() {
     })();
   }, []);
 
-  return <ProfileMain profileImage={profileImage} value={title} inputType="familyEdit" />;
+  return <ProfileMain profileImage={profileImage} value={title} inputType="profile" />;
 }

--- a/src/app/(afterLogin)/(profile)/profile/page.tsx
+++ b/src/app/(afterLogin)/(profile)/profile/page.tsx
@@ -3,7 +3,7 @@ import BasicHeader from '@/app/_components/common/header/BasicHeader';
 
 export default function ProfileEditPage() {
   return (
-    <div>
+    <div className="flex flex-col relative min-h-screen">
       <BasicHeader title="프로필 수정" hasRightButton />
       <UserProfileEditMain />
     </div>

--- a/src/app/(afterLogin)/(profile)/profile/page.tsx
+++ b/src/app/(afterLogin)/(profile)/profile/page.tsx
@@ -1,15 +1,11 @@
-import ProfileMain from '@/app/(afterLogin)/(profile)/_components/ProfileMain';
+import UserProfileEditMain from '@/app/(afterLogin)/(profile)/profile/components/UserProfileEditMain';
 import BasicHeader from '@/app/_components/common/header/BasicHeader';
-
-const PROFILE_IMAGE =
-  'https://avatars.githubusercontent.com/u/49144662?s=400&u=903e697529c3b51f9c69bc3885c8f9be3d754028&v=4';
-const VALUE = '아빠';
 
 export default function ProfileEditPage() {
   return (
     <div>
       <BasicHeader title="프로필 수정" hasRightButton />
-      <ProfileMain profileImage={PROFILE_IMAGE} value={VALUE} inputType="profile" />
+      <UserProfileEditMain />
     </div>
   );
 }

--- a/src/app/_api/api.ts
+++ b/src/app/_api/api.ts
@@ -21,6 +21,10 @@ const makeHeader = async (body: any) => {
     Authorization: `Bearer ${accessToken}`,
   };
 
+  if (body instanceof FormData) {
+    return { headers: { Authorization: `Bearer ${accessToken}` }, body };
+  }
+
   return { headers, body: body ? JSON.stringify(body) : undefined };
 };
 

--- a/src/app/_api/api.ts
+++ b/src/app/_api/api.ts
@@ -21,10 +21,6 @@ const makeHeader = async (body: any) => {
     Authorization: `Bearer ${accessToken}`,
   };
 
-  if (body instanceof FormData) {
-    return { headers: { Authorization: `Bearer ${accessToken}` }, body };
-  }
-
   return { headers, body: body ? JSON.stringify(body) : undefined };
 };
 

--- a/src/app/_api/apiRoutes.ts
+++ b/src/app/_api/apiRoutes.ts
@@ -9,9 +9,8 @@ export const apiRoutes = {
   deleteFamily: '/v1/groups/delete',
 
   // User
-  UpdateProfile: '/v1/users/profile',
   UserLogout: '/v1/users/logout',
   UserDeletion: '/v1/users/delete',
   getUserData: '/v1/users/my',
-  profileUpdate: 'v1/users/update',
+  profileUpdate: '/v1/users/update',
 };

--- a/src/app/_api/apiRoutes.ts
+++ b/src/app/_api/apiRoutes.ts
@@ -13,4 +13,5 @@ export const apiRoutes = {
   UserLogout: '/v1/users/logout',
   UserDeletion: '/v1/users/delete',
   getUserData: '/v1/users/my',
+  profileUpdate: 'v1/users/update',
 };

--- a/src/app/_components/common/header/BasicHeader.tsx
+++ b/src/app/_components/common/header/BasicHeader.tsx
@@ -36,7 +36,7 @@ const decideInputText = (
 
 const decideApiRoute = (pathName: string, groupId?: number) => {
   if (pathName === '/profile') {
-    return { method: 'PUT', path: apiRoutes.UpdateProfile };
+    return { method: 'PUT', path: apiRoutes.profileUpdate };
   }
   if (pathName === '/family') {
     return { method: 'POST', path: apiRoutes.createFamily };
@@ -72,7 +72,7 @@ export default function BasicHeader({ title, hasRightButton }: Props) {
         name: inputText,
       };
 
-      if (selectedImage) {
+      if (selectedImage && !selectedImage.includes('woory-bucket')) {
         data.images = selectedImage;
       }
 
@@ -85,14 +85,14 @@ export default function BasicHeader({ title, hasRightButton }: Props) {
           deleteCookies('groupId');
         }
         setCookies('groupId', groupId);
+        router.push(`/home/${groupId}/daily/${date}`);
         imageReset();
         inputReset();
-        router.push(`/home/${groupId}/daily/${date}`);
       } else if (method === 'PUT') {
         await putData({ path, body: data });
+        router.push('/mypage');
         imageReset();
         inputReset();
-        router.push('/mypage');
       }
     } catch (e) {
       console.error(e);

--- a/src/app/_store/imageUploadStore.ts
+++ b/src/app/_store/imageUploadStore.ts
@@ -3,11 +3,11 @@ import { create } from 'zustand';
 interface ImageUploadState {
   selectedImage: string | null;
   setSelectedImage: (image: string | null) => void;
-  reset: () => void;
+  imageReset: () => void;
 }
 
 export const useImageUploadStore = create<ImageUploadState>((set) => ({
   selectedImage: null,
   setSelectedImage: (image) => set({ selectedImage: image }),
-  reset: () => set({ selectedImage: null }),
+  imageReset: () => set({ selectedImage: null }),
 }));

--- a/src/app/_store/inputStore.ts
+++ b/src/app/_store/inputStore.ts
@@ -9,7 +9,7 @@ export interface InputState {
   setInputProfileText: (text: string) => void;
   inputFamilyEditText: string;
   setInputFamilyEditText: (text: string) => void;
-  reset: () => void;
+  inputReset: () => void;
 }
 
 export const useInputStore = create<InputState>((set) => ({
@@ -21,5 +21,5 @@ export const useInputStore = create<InputState>((set) => ({
   setInputProfileText: (text) => set({ inputProfileText: text }),
   inputFamilyEditText: '',
   setInputFamilyEditText: (text) => set({ inputFamilyEditText: text }),
-  reset: () => set({ inputText: '' }),
+  inputReset: () => set({ inputText: '', inputFamilyText: '', inputProfileText: '', inputFamilyEditText: '' }),
 }));

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -110,7 +110,7 @@ export type UserDataType = {
   userEmail?: string;
   nickname: string;
   profileImgLink: string;
-  isHouseholder: boolean;
+  isHouseHolder: boolean;
   isLastMember: boolean;
 };
 

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -131,6 +131,6 @@ export type ModalTypeMap = {
 };
 
 export type ProfileSaveType = {
-  groupName: string;
-  groupPhoto?: string;
+  name: string;
+  images?: string;
 };


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#139
## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 프로필 수정 API - 유저 프로필 GET, 수정 PUT 연결
- 프로필 수정, 가족 상태 수정, 가족 생성 시 이미지를 formdata => string 으로 타입 변환하여 requset data에 보내줌
- 사용자가 이미지는 변경하지 않고 이름만 변경하고 저장을 했을 때 오류 발생 => 현재 selectedImage의 값에 "woory-bucket" 키워드가 포함 되어있을 경우 images 필드를 제외하도록 함
- 가족 삭제 시 image 상태 reset 
-  input 상태 데이터 reset 처리

## 스크린샷(선택)
